### PR TITLE
Increase gas to infinite

### DIFF
--- a/foundry.toml
+++ b/foundry.toml
@@ -1,6 +1,7 @@
 [profile.default]
 solc_version = "0.8.17"
 no_match_test = "testGasUsage"
+gas_limit = "18446744073709551615" # 2^64 - 1, to remove the gas limit
 
 [profile.gas]
 no_match_test = "None"


### PR DESCRIPTION
Removes the gas limit, to recover tests failing since the following update of forge:
- https://github.com/foundry-rs/foundry/pull/8274

See for example [this run](https://github.com/morpho-org/morpho-data-structures/actions/runs/9741739217/job/26891516918)
