### PR TITLE
test: update halmos tests for new halmos version

### DIFF
--- a/.github/workflows/ci-foundry.yml
+++ b/.github/workflows/ci-foundry.yml
@@ -47,4 +47,4 @@ jobs:
         run: python3 -m pip install --upgrade halmos
 
       - name: Run halmos
-        run: halmos --function testProve --loop 4 --test-parallel --solver-timeout-assertion 0
+        run: halmos --function testProve --loop 4 --solver-timeout-assertion 0

--- a/.github/workflows/ci-foundry.yml
+++ b/.github/workflows/ci-foundry.yml
@@ -47,4 +47,4 @@ jobs:
         run: python3 -m pip install --upgrade halmos
 
       - name: Run halmos
-        run: halmos --function testProve --loop 4 --symbolic-storage --test-parallel --solver-parallel --solver-timeout-assertion 0
+        run: halmos --function testProve --loop 4 --test-parallel --solver-timeout-assertion 0

--- a/.gitmodules
+++ b/.gitmodules
@@ -5,6 +5,9 @@
 	path = lib/forge-std
 	url = https://github.com/MathisGD/forge-std
 	branch = feat/real-gas-consumption
+[submodule "lib/halmos-cheatcodes"]
+	path = lib/halmos-cheatcodes
+	url = https://github.com/a16z/halmos-cheatcodes
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/OpenZeppelin/openzeppelin-contracts

--- a/test/TestLogarithmicBuckets.t.sol
+++ b/test/TestLogarithmicBuckets.t.sol
@@ -120,7 +120,7 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
 }
 
 contract TestProveLogarithmicBuckets is LogarithmicBucketsMock, Test, SymTest {
-    function setUp() public {
+    function setUpSymbolic() public {
         svm.enableSymbolicStorage(address(this));
     }
 

--- a/test/TestLogarithmicBuckets.t.sol
+++ b/test/TestLogarithmicBuckets.t.sol
@@ -2,6 +2,7 @@
 pragma solidity ^0.8.0;
 
 import {Test} from "forge-std/Test.sol";
+import {SymTest} from "halmos-cheatcodes/SymTest.sol";
 import {
     LogarithmicBucketsMock, BucketDLLMock, BucketDLL, LogarithmicBuckets
 } from "./mocks/LogarithmicBucketsMock.sol";
@@ -118,7 +119,11 @@ contract TestLogarithmicBuckets is LogarithmicBucketsMock, Test {
     }
 }
 
-contract TestProveLogarithmicBuckets is LogarithmicBucketsMock, Test {
+contract TestProveLogarithmicBuckets is LogarithmicBucketsMock, Test, SymTest {
+    function setUp() public {
+        svm.enableSymbolicStorage(address(this));
+    }
+
     function isPowerOfTwo(uint256 x) public pure returns (bool) {
         unchecked {
             return x != 0 && (x & (x - 1)) == 0;


### PR DESCRIPTION
This PR updates the existing halmos tests to accommodate changes in [the latest version](https://github.com/a16z/halmos/releases/tag/v0.2.0) of halmos.

Changes:
- Replaced the `--symbolic-storage` flag with the `enableSymbolicStorage(address)` cheatcode, as the former has been deprecated in the new halmos version.
- Removed `--solver-parallel`, as it is now enabled by default.
- Removed `--test-parallel`, which will be deprecated in the next release in preparation for portfolio solving.