### PR TITLE
Use only POSIX compliant sed features

### DIFF
--- a/certora/Makefile
+++ b/certora/Makefile
@@ -7,7 +7,7 @@ munged-simple: $(wildcard ../src/*.sol) applyHarnessSimple.patch
 	@patch -p0 -d munged-simple < applyHarnessSimple.patch
 
 record-simple:
-	diff -ruN ../src munged-simple | sed 's,\.\./src/\|munged-simple/,,g' | sed 's,\(\(\-\-\-\|+++\) [^[:space:]]*\).*,\1,' > applyHarnessSimple.patch
+	diff -ruN ../src munged-simple | sed -E 's,\.\./src/|munged-simple/,,g' | sed -E 's,((\-\-\-|\+\+\+) [^[:space:]]*).*,\1,' > applyHarnessSimple.patch
 
 munged-fifo: $(wildcard ../src/*.sol) applyHarnessFifo.patch
 	@rm -rf munged-fifo
@@ -15,7 +15,7 @@ munged-fifo: $(wildcard ../src/*.sol) applyHarnessFifo.patch
 	@patch -p0 -d munged-fifo < applyHarnessFifo.patch
 
 record-fifo:
-	diff -ruN ../src munged-fifo | sed 's,\.\./src/\|munged-fifo/,,g' | sed 's,\(\(\-\-\-\|+++\) [^[:space:]]*\).*,\1,' > applyHarnessFifo.patch
+	diff -ruN ../src munged-fifo | sed -E 's,\.\./src/|munged-fifo/,,g' | sed -E 's,((\-\-\-|\+\+\+) [^[:space:]]*).*,\1,' > applyHarnessFifo.patch
 
 clean:
 	rm -rf munged-simple munged-fifo


### PR DESCRIPTION
Apparently basic regular expressions (BRE) do not have the OR operator by default. This PR uses extended regular expressions (ERE) so that it should work with any compliant system
See https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap09.html

Test by doing `make -C certora clean munged-simple record-simple` and check that there is no diff